### PR TITLE
Add missing arguments required by rails 6+

### DIFF
--- a/lib/jasmine-rails-webpacker/page.rb
+++ b/lib/jasmine-rails-webpacker/page.rb
@@ -19,7 +19,8 @@ module Jasmine
     attr_reader :lookup_context, :extra_js
 
     def view
-      @view ||= ActionView::Base.with_empty_template_cache.new(lookup_context)
+      # Pass missing default arguments that are required for rails 6+
+      @view ||= ActionView::Base.with_empty_template_cache.new(lookup_context, [], nil)
     end
   end
 end


### PR DESCRIPTION
This fixes the errors being thrown when running webpacker + jasmine on top of rails 6.  